### PR TITLE
BT-4684 Add path import for isSupportedFileExtension

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -1,4 +1,5 @@
 const {ILLEGAL_FILE_PATH_CHARS, SUPPORTED_EXTENSIONS, SUPPORTED_MIME_TYPES} = require('./constants');
+const path = require('path');
 
   /**
    * Checks if a string (usually a filename) contains any illegal characters.


### PR DESCRIPTION
This PR adds the `path` import so `isSupportedFileExtension` doesn't throw an error. Encountered while testing `addESignature` endpoint.

![image](https://github.com/Bluetail-aero/bluetail-globals/assets/49412203/4b24b21f-41b7-4a15-8887-e5f4c12f2484)
