### PR TITLE
Fix AircraftId export

### DIFF
--- a/AircraftId.js
+++ b/AircraftId.js
@@ -102,4 +102,4 @@ class AircraftId {
   }
 }
 
-exports.AircraftId = AircraftId;
+module.exports = AircraftId;


### PR DESCRIPTION
Tested `aircraftId2Tailnumber` legacy function and using the new `AircraftId` class from the backend. Both worked! And fixed this error:

![image](https://github.com/user-attachments/assets/dc0fe5ee-ae6a-4b7b-a764-3b88c5c72e7f)
